### PR TITLE
支持多个View都使用MJRefresh控件时，最后刷新时间可独立保存

### DIFF
--- a/MJRefreshExample/MJRefreshExample/MJRefresh/MJRefreshHeaderView.h
+++ b/MJRefreshExample/MJRefreshExample/MJRefresh/MJRefreshHeaderView.h
@@ -9,5 +9,8 @@
 #import "MJRefreshBaseView.h"
 
 @interface MJRefreshHeaderView : MJRefreshBaseView
+
+@property NSString *dateKey;
 + (instancetype)header;
+
 @end

--- a/MJRefreshExample/MJRefreshExample/MJRefresh/MJRefreshHeaderView.m
+++ b/MJRefreshExample/MJRefreshExample/MJRefresh/MJRefreshHeaderView.m
@@ -35,7 +35,11 @@
         [self addSubview:_lastUpdateTimeLabel = lastUpdateTimeLabel];
         
         // 2.加载时间
-        self.lastUpdateTime = [[NSUserDefaults standardUserDefaults] objectForKey:MJRefreshHeaderTimeKey];
+        if(!self.dateKey){
+            self.lastUpdateTime = [[NSUserDefaults standardUserDefaults] objectForKey:MJRefreshHeaderTimeKey];
+        }else{
+            self.lastUpdateTime = [[NSUserDefaults standardUserDefaults] objectForKey:self.dateKey];
+        }
     }
     return _lastUpdateTimeLabel;
 }
@@ -89,8 +93,11 @@
     _lastUpdateTime = lastUpdateTime;
     
     // 1.归档
-    [[NSUserDefaults standardUserDefaults] setObject:lastUpdateTime forKey:MJRefreshHeaderTimeKey];
-    [[NSUserDefaults standardUserDefaults] synchronize];
+    if(!self.dateKey){
+        [[NSUserDefaults standardUserDefaults] setObject:lastUpdateTime forKey:MJRefreshHeaderTimeKey];
+    }else{
+        [[NSUserDefaults standardUserDefaults] setObject:lastUpdateTime forKey:self.dateKey];
+    }
     
     // 2.更新时间
     [self updateTimeLabel];

--- a/MJRefreshExample/MJRefreshExample/MJRefresh/UIScrollView+MJRefresh.h
+++ b/MJRefreshExample/MJRefreshExample/MJRefresh/UIScrollView+MJRefresh.h
@@ -20,10 +20,27 @@
 /**
  *  添加一个下拉刷新头部控件
  *
+ *  @param callback 回调
+ *  @param dateKey 刷新时间保存的key值
+ */
+- (void)addHeaderWithCallback:(void (^)())callback dateKey:(NSString*)dateKey;
+
+/**
+ *  添加一个下拉刷新头部控件
+ *
  *  @param target 目标
  *  @param action 回调方法
  */
 - (void)addHeaderWithTarget:(id)target action:(SEL)action;
+
+/**
+ *  添加一个下拉刷新头部控件
+ *
+ *  @param target 目标
+ *  @param action 回调方法
+ *  @param dateKey 刷新时间保存的key值
+ */
+- (void)addHeaderWithTarget:(id)target action:(SEL)action dateKey:(NSString*)dateKey;
 
 /**
  *  移除下拉刷新头部控件

--- a/MJRefreshExample/MJRefreshExample/MJRefresh/UIScrollView+MJRefresh.m
+++ b/MJRefreshExample/MJRefreshExample/MJRefresh/UIScrollView+MJRefresh.m
@@ -66,6 +66,12 @@ static char MJRefreshFooterViewKey;
     self.header.beginRefreshingCallback = callback;
 }
 
+- (void)addHeaderWithCallback:(void (^)())callback dateKey:(NSString*)dateKey
+{
+    [self addHeaderWithCallback:callback];
+    self.header.dateKey = dateKey;
+}
+
 /**
  *  添加一个下拉刷新头部控件
  *
@@ -84,6 +90,12 @@ static char MJRefreshFooterViewKey;
     // 2.设置目标和回调方法
     self.header.beginRefreshingTaget = target;
     self.header.beginRefreshingAction = action;
+}
+
+- (void)addHeaderWithTarget:(id)target action:(SEL)action dateKey:(NSString*)dateKey
+{
+    [self addHeaderWithTarget:target action:action];
+    self.header.dateKey = dateKey;
 }
 
 /**


### PR DESCRIPTION
@CoderMJLee 

我们的APP，报表页面和通讯录页面都需要下拉刷新，但是这2个动作是独立的，因此需要分别保存各自的最后刷新时间

增加了一个dateKey字段，没有这个场景的用户，还是使用原来的方法：

``` oc
- (void)addHeaderWithCallback:(void (^)())callback;
```

需要单独保存的，使用新增加的方法：

``` oc
- (void)addHeaderWithCallback:(void (^)())callback dateKey:(NSString*)dateKey;
```

在需要从SP里保存和读取时间时，增加判断：

``` oc
if(!self.dateKey){
        [[NSUserDefaults standardUserDefaults] setObject:lastUpdateTime forKey:MJRefreshHeaderTimeKey];
    }else{
        [[NSUserDefaults standardUserDefaults] setObject:lastUpdateTime forKey:self.dateKey];
    }
```
