### PR TITLE
Update IPHONEOS_DEPLOYMENT_TARGET to 6.0.

### DIFF
--- a/MJRefreshExample/MJRefreshExample.xcodeproj/project.pbxproj
+++ b/MJRefreshExample/MJRefreshExample.xcodeproj/project.pbxproj
@@ -469,6 +469,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = MJRefreshExample/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
@@ -479,6 +480,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = MJRefreshExample/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};


### PR DESCRIPTION
根据文档，把这里改成了6.0。这样开发者 clone 后不需要修改工程配置就可以运行 demo了。