### PR TITLE
当有多个tableView横向排布的时候,因为在iOS7中会有UITableViewWrapperView,所以刷新控件会被拉伸

### DIFF
--- a/MJRefreshExample/MJRefreshExample/MJRefresh/UIView+MJExtension.m
+++ b/MJRefreshExample/MJRefreshExample/MJRefresh/UIView+MJExtension.m
@@ -43,7 +43,7 @@
 
 - (CGFloat)mj_w
 {
-    return self.frame.size.width;
+    return MIN([UIScreen mainScreen].bounds.size.width, self.frame.size.width);
 }
 
 - (void)setMj_h:(CGFloat)mj_h


### PR DESCRIPTION
当有多个tableView横向排布的时候,因为在iOS7中会有UITableViewWrapperView,所以刷新控件会被拉伸