### PR TITLE
Fix bug that, when set images of MJRefreshGifHeader before add it to super view, it's height is improperly reset to MJRefreshHeaderHeight when it is being added to super view.

### DIFF
--- a/MJRefreshExample/MJRefreshExample/MJRefresh/MJRefreshHeader.m
+++ b/MJRefreshExample/MJRefreshExample/MJRefresh/MJRefreshHeader.m
@@ -73,17 +73,10 @@
         [self setTitle:MJRefreshHeaderStateIdleText forState:MJRefreshHeaderStateIdle];
         [self setTitle:MJRefreshHeaderStatePullingText forState:MJRefreshHeaderStatePulling];
         [self setTitle:MJRefreshHeaderStateRefreshingText forState:MJRefreshHeaderStateRefreshing];
+        
+        self.mj_h = MJRefreshHeaderHeight; // Default
     }
     return self;
-}
-
-- (void)willMoveToSuperview:(UIView *)newSuperview
-{
-    [super willMoveToSuperview:newSuperview];
-    
-    if (newSuperview) {
-        self.mj_h = MJRefreshHeaderHeight;
-    }
 }
 
 - (void)layoutSubviews


### PR DESCRIPTION
修正调用顺序导致 header view 高度异常的问题。