### PR TITLE
Update MJRefreshFooter.m

### DIFF
--- a/MJRefreshExample/MJRefreshExample/MJRefresh/MJRefreshFooter.m
+++ b/MJRefreshExample/MJRefreshExample/MJRefresh/MJRefreshFooter.m
@@ -269,15 +269,19 @@
             break;
             
         case MJRefreshFooterStateRefreshing:
+        {
             self.loadMoreButton.hidden = YES;
             self.noMoreLabel.hidden = YES;
             if (!self.stateHidden) self.stateLabel.hidden = NO;
-            if (self.refreshingBlock) {
-                self.refreshingBlock();
-            }
-            if ([self.refreshingTarget respondsToSelector:self.refreshingAction]) {
-                msgSend(msgTarget(self.refreshingTarget), self.refreshingAction, self);
-            }
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                if (self.refreshingBlock) {
+                    self.refreshingBlock();
+                }
+                if ([self.refreshingTarget respondsToSelector:self.refreshingAction]) {
+                    msgSend(msgTarget(self.refreshingTarget), self.refreshingAction, self);
+                }
+            });
+        }
             break;
             
         case MJRefreshFooterStateNoMoreData:


### PR DESCRIPTION
实际开发中，上拉刷新数据reload完毕之后会立即调用endRefresh，产生上拉刷新频繁调用，需要延时执行