### PR TITLE
修复 loadMoreButton 和 noMoreLabel 有时同时显示的问题.

### DIFF
--- a/MJRefreshExample/MJRefreshExample/MJRefresh/MJRefreshFooter.m
+++ b/MJRefreshExample/MJRefreshExample/MJRefresh/MJRefreshFooter.m
@@ -271,7 +271,7 @@
             
             //修复传统上拉加载更多在 UITableView 使用 '- (void)insertRowsAtIndexPaths:(NSArray *)indexPaths withRowAnimation:(UITableViewRowAnimation)animation;'方法加载更多数据时露出按钮的的问题
             dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.3 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-                self.loadMoreButton.hidden = NO;
+                self.loadMoreButton.hidden = self.state != MJRefreshFooterStateIdle;
             });
         }
             break;


### PR DESCRIPTION
在 viewDidLoad 的时候 调用了 addLegendFooterWithRefreshingTarget, 然后 0.3秒内有数据返回, 此时判断了发现 no more data, 调用 noticeNoMoreData, 然后到达0.3秒, self.loadMoreButton.hidden = NO; 被调用, 导致 loadMoreButton 和 noMoreLabel 同时显示.