### PR TITLE
修复增加contentInset的显式动画，与UICollectionView的隐式动画冲突的问题。

### DIFF
--- a/MJRefresh/Base/MJRefreshHeader.h
+++ b/MJRefresh/Base/MJRefreshHeader.h
@@ -22,4 +22,8 @@
 
 /** 忽略多少scrollView的contentInset的top */
 @property (assign, nonatomic) CGFloat ignoredScrollViewContentInsetTop;
+
+/** 是否以动画显示开始刷新前的回弹效果 */
+@property BOOL shouldAnimateWhenRefreshing;
+
 @end

--- a/MJRefresh/Base/MJRefreshHeader.m
+++ b/MJRefresh/Base/MJRefreshHeader.m
@@ -38,6 +38,9 @@
     
     // 设置高度
     self.mj_h = MJRefreshHeaderHeight;
+    
+    // 默认应该以动画显示开始刷新前的回弹效果
+    self.shouldAnimateWhenRefreshing = YES;
 }
 
 - (void)placeSubviews
@@ -111,16 +114,30 @@
             self.pullingPercent = 0.0;
         }];
     } else if (state == MJRefreshStateRefreshing) {
-        [UIView animateWithDuration:MJRefreshFastAnimationDuration animations:^{
+        
+        if(self.shouldAnimateWhenRefreshing){
+            
+            [UIView animateWithDuration:MJRefreshFastAnimationDuration animations:^{
+                // 增加滚动区域
+                CGFloat top = self.scrollViewOriginalInset.top + self.mj_h;
+                self.scrollView.mj_insetT = top;
+                
+                // 设置滚动位置
+                self.scrollView.mj_offsetY = - top;
+            } completion:^(BOOL finished) {
+                [self executeRefreshingCallback];
+            }];
+        }else{
+            
             // 增加滚动区域
             CGFloat top = self.scrollViewOriginalInset.top + self.mj_h;
             self.scrollView.mj_insetT = top;
             
             // 设置滚动位置
             self.scrollView.mj_offsetY = - top;
-        } completion:^(BOOL finished) {
+            
             [self executeRefreshingCallback];
-        }];
+        }
     }
 }
 


### PR DESCRIPTION
在MJRefreshHeader增加shouldAnimateWhenRefreshing属性，默认为YES。如果出现动画冲突的情况，将该属性设置成NO
