### PR TITLE
Fix footer automaticallyHidden but not shown

### DIFF
--- a/MJRefresh/Base/MJRefreshFooter.m
+++ b/MJRefresh/Base/MJRefreshFooter.m
@@ -42,9 +42,10 @@
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
 {
-    [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
     if (self.isAutomaticallyHidden && self.userInteractionEnabled && object == self.scrollView && [keyPath isEqualToString:MJRefreshKeyPathContentSize]) {
         [self scrollViewContentSizeDidChange:change];
+    } else {
+        [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
     }
 }
 

--- a/MJRefresh/Base/MJRefreshFooter.m
+++ b/MJRefresh/Base/MJRefreshFooter.m
@@ -40,6 +40,13 @@
     self.automaticallyHidden = YES;
 }
 
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
+{
+    [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+    if (self.isAutomaticallyHidden && self.userInteractionEnabled && object == self.scrollView && [keyPath isEqualToString:MJRefreshKeyPathContentSize]) {
+        [self scrollViewContentSizeDidChange:change];
+    }
+}
 
 - (void)scrollViewContentSizeDidChange:(NSDictionary *)change
 {


### PR DESCRIPTION
如题，重现场景如下：

1. 进入列表视图，在viewDidLoad中添加MJRefreshAutoNormalFooter，开始向服务器请求数据，由于这个时候页面中没有数据，并且MJRefreshFooter的默认automaticallyHidden是YES，所以footer.hidden被自动设成了YES

2. 服务器加载数据完毕，tableView调用reloadData从而触发了contentSize的KVO。本应该走到scrollViewContentSizeDidChange:方法，但是这个hidden的值将这个方法挡住，由此导致一次hidden自动设置成YES后，无法自动恢复回来
![image](https://cloud.githubusercontent.com/assets/5186464/9202350/0037d75e-4084-11e5-8ff7-c386b4e8639b.png)

本想在MJRefreshComponent当前KVO方法加入MJRefreshFooter是否加入automaticallyHidden这一方法的判断，但感觉父类还是不要拿子类比较好，于是想到在子类中重写KVO并加入一系列判断，保证在automaticallyHidden置为YES的情况下时刻刷新footer的hidden。

如果有更好的方法还请指教~
