### PR TITLE
去掉重复调用totalDataCount

### DIFF
--- a/MJRefresh/Base/MJRefreshFooter.m
+++ b/MJRefresh/Base/MJRefreshFooter.m
@@ -48,7 +48,7 @@
         // 监听scrollView数据的变化
         [self.scrollView setReloadDataBlock:^(NSInteger totalDataCount) {
             if (self.isAutomaticallyHidden) {
-                self.hidden = (self.scrollView.totalDataCount == 0);
+                self.hidden = (totalDataCount == 0);
             }
         }];
     }


### PR DESCRIPTION
这里可以用传入的totalDataCount，不必再次调用self.scrollView.totalDataCount。
另外，self.scrollView.totalDataCount函数可否优化为：遍历到table有数据即可返回，因为返回的这个totalDataCount值也仅仅是用在这里和0比较，设置self.hidden。（这个PR里暂时没有做这个优化）