### PR TITLE
自动处理是否需要添加Footer

### DIFF
--- a/MJRefresh/UIScrollView+MJRefresh.m
+++ b/MJRefresh/UIScrollView+MJRefresh.m
@@ -55,6 +55,9 @@ static const char MJRefreshFooterKey = '\0';
 - (void)setFooter:(MJRefreshFooter *)footer
 {
     if (footer != self.footer) {
+        // 如果内容太少，不添加Footer
+        if (self.contentSize.height <= self.frame.size.height) return;
+        
         // 删除旧的，添加新的
         [self.footer removeFromSuperview];
         [self addSubview:footer];


### PR DESCRIPTION
实际项目开发中，处理在刷新的内容太少，高度没有超过ScrollView自身高度时，不添加Footer
