### PR TITLE
xcode6.4 编译错误

### DIFF
--- a/MJRefresh/Custom/Header/MJRefreshStateHeader.m
+++ b/MJRefresh/Custom/Header/MJRefreshStateHeader.m
@@ -55,7 +55,7 @@
 
 #pragma mark - 日历获取在9.x之后的系统使用currentCalendar会出异常。在8.0之后使用系统新API。
 - (NSCalendar *)currentCalendar {
-    if (NSFoundationVersionNumber >= NSFoundationVersionNumber_iOS_8_0) {
+    if ([NSCalendar instancesRespondToSelector:@selector(calendarWithIdentifier:)]) {
         return [NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian];
     }
     return [NSCalendar currentCalendar];


### PR DESCRIPTION
NSFoundationVersionNumber_iOS_8_0 这个宏在xcode6.4下没定义