### PR TITLE
允许用户自定义箭头图标的偏移量

### DIFF
--- a/MJRefresh/Custom/Header/MJRefreshNormalHeader.h
+++ b/MJRefresh/Custom/Header/MJRefreshNormalHeader.h
@@ -10,6 +10,8 @@
 
 @interface MJRefreshNormalHeader : MJRefreshStateHeader
 @property (weak, nonatomic, readonly) UIImageView *arrowView;
+/** 箭头图标距离中心偏移量 **/
+@property (assign, nonatomic) CGFloat arrowViewOffset;
 /** 菊花的样式 */
 @property (assign, nonatomic) UIActivityIndicatorViewStyle activityIndicatorViewStyle;
 @end

--- a/MJRefresh/Custom/Header/MJRefreshNormalHeader.m
+++ b/MJRefresh/Custom/Header/MJRefreshNormalHeader.m
@@ -52,6 +52,7 @@
     [super prepare];
     
     self.activityIndicatorViewStyle = UIActivityIndicatorViewStyleGray;
+    self.arrowViewOffset = -100;
 }
 
 - (void)placeSubviews
@@ -61,7 +62,7 @@
     // 箭头的中心点
     CGFloat arrowCenterX = self.mj_w * 0.5;
     if (!self.stateLabel.hidden) {
-        arrowCenterX -= 100;
+        arrowCenterX += self.arrowViewOffset;
     }
     CGFloat arrowCenterY = self.mj_h * 0.5;
     CGPoint arrowCenter = CGPointMake(arrowCenterX, arrowCenterY);


### PR DESCRIPTION
目前箭头的位置是固定的相左偏移100. 但是当文字很少的时候，就会距离文字太大。所以添加了一个偏移量的属性允许用户自定义。
