### PR TITLE
Renamed the class method in UILabel's category.

### DIFF
--- a/MJRefresh/Base/MJRefreshComponent.h
+++ b/MJRefresh/Base/MJRefreshComponent.h
@@ -89,5 +89,5 @@ typedef void (^MJRefreshComponentRefreshingBlock)();
 @end
 
 @interface UILabel(MJRefresh)
-+ (instancetype)label;
++ (instancetype)mj_label;
 @end

--- a/MJRefresh/Base/MJRefreshComponent.m
+++ b/MJRefresh/Base/MJRefreshComponent.m
@@ -216,7 +216,7 @@
 @end
 
 @implementation UILabel(MJRefresh)
-+ (instancetype)label
++ (instancetype)mj_label
 {
     UILabel *label = [[self alloc] init];
     label.font = MJRefreshLabelFont;

--- a/MJRefresh/Custom/Footer/Auto/MJRefreshAutoStateFooter.m
+++ b/MJRefresh/Custom/Footer/Auto/MJRefreshAutoStateFooter.m
@@ -30,7 +30,7 @@
 - (UILabel *)stateLabel
 {
     if (!_stateLabel) {
-        [self addSubview:_stateLabel = [UILabel label]];
+        [self addSubview:_stateLabel = [UILabel mj_label]];
     }
     return _stateLabel;
 }

--- a/MJRefresh/Custom/Footer/Back/MJRefreshBackStateFooter.m
+++ b/MJRefresh/Custom/Footer/Back/MJRefreshBackStateFooter.m
@@ -30,7 +30,7 @@
 - (UILabel *)stateLabel
 {
     if (!_stateLabel) {
-        [self addSubview:_stateLabel = [UILabel label]];
+        [self addSubview:_stateLabel = [UILabel mj_label]];
     }
     return _stateLabel;
 }

--- a/MJRefresh/Custom/Header/MJRefreshStateHeader.m
+++ b/MJRefresh/Custom/Header/MJRefreshStateHeader.m
@@ -32,7 +32,7 @@
 - (UILabel *)stateLabel
 {
     if (!_stateLabel) {
-        [self addSubview:_stateLabel = [UILabel label]];
+        [self addSubview:_stateLabel = [UILabel mj_label]];
     }
     return _stateLabel;
 }
@@ -40,7 +40,7 @@
 - (UILabel *)lastUpdatedTimeLabel
 {
     if (!_lastUpdatedTimeLabel) {
-        [self addSubview:_lastUpdatedTimeLabel = [UILabel label]];
+        [self addSubview:_lastUpdatedTimeLabel = [UILabel mj_label]];
     }
     return _lastUpdatedTimeLabel;
 }


### PR DESCRIPTION
Creating a category for UILabel will cause a duplicated symbol issue in high layer project.

`+ (instancetype)label;`

Added brief prefix for it, please check it.