### PR TITLE
修改MJRefreshNormalHeader.arrowView的renderingMode为AlwaysTemplate，使得可以更改下拉箭头图片的颜色

### DIFF
--- a/MJRefresh/Custom/Header/MJRefreshNormalHeader.m
+++ b/MJRefresh/Custom/Header/MJRefreshNormalHeader.m
@@ -22,6 +22,7 @@
     if (!_arrowView) {
         UIImage *image = [UIImage imageNamed:MJRefreshSrcName(@"arrow.png")] ?: [UIImage imageNamed:MJRefreshFrameworkSrcName(@"arrow.png")];
         UIImageView *arrowView = [[UIImageView alloc] initWithImage:[image imageWithRenderingMode:(UIImageRenderingModeAlwaysTemplate)]];
+        arrowView.tintColor = self.stateLabel.textColor;
         [self addSubview:_arrowView = arrowView];
     }
     return _arrowView;

--- a/MJRefresh/Custom/Header/MJRefreshNormalHeader.m
+++ b/MJRefresh/Custom/Header/MJRefreshNormalHeader.m
@@ -21,7 +21,7 @@
 {
     if (!_arrowView) {
         UIImage *image = [UIImage imageNamed:MJRefreshSrcName(@"arrow.png")] ?: [UIImage imageNamed:MJRefreshFrameworkSrcName(@"arrow.png")];
-        UIImageView *arrowView = [[UIImageView alloc] initWithImage:image];
+        UIImageView *arrowView = [[UIImageView alloc] initWithImage:[image imageWithRenderingMode:(UIImageRenderingModeAlwaysTemplate)]];
         [self addSubview:_arrowView = arrowView];
     }
     return _arrowView;


### PR DESCRIPTION
修改MJRefreshNormalHeader.arrowView的renderingMode为AlwaysTemplate，使得可以更改下拉箭头图片的颜色
header.arrowView?.tintColor = UIColor.whiteColor().colorWithAlphaComponent(0.7)