### PR TITLE
fix a bug of header

### DIFF
--- a/MJRefresh/Base/MJRefreshHeader.m
+++ b/MJRefresh/Base/MJRefreshHeader.m
@@ -141,9 +141,7 @@
 #pragma mark - 公共方法
 - (void)endRefreshing
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        self.state = MJRefreshStateIdle;
-    });
+    self.state = MJRefreshStateIdle;
 }
 
 - (NSDate *)lastUpdatedTime


### PR DESCRIPTION
If you call endRefreshing before beginRefreshing, the header will stay
at the top of the scrollView and never disappear, I think that’s due to
the async handle.
