### PR TITLE
解决MJRefreshHeader中异步更改UI为Refreshing状态导致内部状态和UI状态不一致的问题

### DIFF
--- a/MJRefresh/Base/MJRefreshHeader.m
+++ b/MJRefresh/Base/MJRefreshHeader.m
@@ -124,17 +124,15 @@
             }
         }];
     } else if (state == MJRefreshStateRefreshing) {
-         dispatch_async(dispatch_get_main_queue(), ^{
-            [UIView animateWithDuration:MJRefreshFastAnimationDuration animations:^{
-                CGFloat top = self.scrollViewOriginalInset.top + self.mj_h;
-                // 增加滚动区域top
-                self.scrollView.mj_insetT = top;
-                // 设置滚动位置
-                [self.scrollView setContentOffset:CGPointMake(0, -top) animated:NO];
-            } completion:^(BOOL finished) {
-                [self executeRefreshingCallback];
-            }];
-         });
+        [UIView animateWithDuration:MJRefreshFastAnimationDuration animations:^{
+            CGFloat top = self.scrollViewOriginalInset.top + self.mj_h;
+            // 增加滚动区域top
+            self.scrollView.mj_insetT = top;
+            // 设置滚动位置
+            [self.scrollView setContentOffset:CGPointMake(0, -top) animated:NO];
+        } completion:^(BOOL finished) {
+            [self executeRefreshingCallback];
+        }];
     }
 }
 


### PR DESCRIPTION
详细描述可见我的博客文章
http://www.jianshu.com/p/0ecaf3d67940

在MJRefreshHeader类setState方法中“更改UI为refreshing状态”的操作是异步的。也就是说，设置Refreshing状态时，设置内部状态和设置UI状态被分离开了，如果在中间插入了设置内部状态（比如Idle）的操作可能会导致内部状态和UI状态不一致的问题。另外，MJRefreshendRefreshing方法中“设置状态为Idle”操作是异步的。
出现问题的原因就是两次异步，由于执行顺序的原因，导致内部状态和UI状态不一致。

设置refreshing状态如果需要异步，应该像设置idle状态一样，整体异步（beginRefreshing应该参考endRefreshing的实现，需要异步的话）这边不了解，可以自行修改
