### PR TITLE
控制Header下拉后,回滚到初始位置的动画

### DIFF
--- a/MJRefresh/Base/MJRefreshHeader.h
+++ b/MJRefresh/Base/MJRefreshHeader.h
@@ -22,4 +22,9 @@
 
 /** 忽略多少scrollView的contentInset的top */
 @property (assign, nonatomic) CGFloat ignoredScrollViewContentInsetTop;
+
+
+/** 控制Header下拉后, 回滚到初始位置的动画 */
+@property (assign, nonatomic) BOOL stopHeaderScrollBackAnimate;
+
 @end

--- a/MJRefresh/Base/MJRefreshHeader.m
+++ b/MJRefresh/Base/MJRefreshHeader.m
@@ -110,8 +110,13 @@
         [[NSUserDefaults standardUserDefaults] setObject:[NSDate date] forKey:self.lastUpdatedTimeKey];
         [[NSUserDefaults standardUserDefaults] synchronize];
         
+        NSTimeInterval interval = MJRefreshSlowAnimationDuration;
+        if (self.stopHeaderScrollBackAnimate) {
+            interval = 0;
+        }
+        
         // 恢复inset和offset
-        [UIView animateWithDuration:MJRefreshSlowAnimationDuration animations:^{
+        [UIView animateWithDuration:interval animations:^{
             self.scrollView.mj_insetT += self.insetTDelta;
             
             // 自动调整透明度


### PR DESCRIPTION
在例如微信下拉加载历史消息的情形下, 这个动画会影响流畅性.