### PR TITLE
解决footview已经隐藏，又被显示出来

### DIFF
--- a/MJRefresh/Base/MJRefreshFooter.m
+++ b/MJRefresh/Base/MJRefreshFooter.m
@@ -49,7 +49,9 @@
         if ([self.scrollView isKindOfClass:[UITableView class]] || [self.scrollView isKindOfClass:[UICollectionView class]]) {
             [self.scrollView setMj_reloadDataBlock:^(NSInteger totalDataCount) {
                 if (self.isAutomaticallyHidden) {
-                    self.hidden = (totalDataCount == 0);
+                    if (!self.hidden) {
+                        self.hidden = (totalDataCount == 0);
+                    }
                 }
             }];
         }


### PR DESCRIPTION
```
- (void)willMoveToSuperview:(UIView *)newSuperview
{
    [super willMoveToSuperview:newSuperview];
    
    if (newSuperview) {
        // 监听scrollView数据的变化
        if ([self.scrollView isKindOfClass:[UITableView class]] || [self.scrollView isKindOfClass:[UICollectionView class]]) {
            [self.scrollView setMj_reloadDataBlock:^(NSInteger totalDataCount) {
                if (self.isAutomaticallyHidden) {
                    self.hidden = (totalDataCount == 0);
                }
            }];
        }
    }
}   
```
我已经设置footerView.hidden为YES, 但是如果totalDataCount不为零的情况footerView.hidden会被又设置为NO