### PR TITLE
修改 Crash 问题 UIScrollView+MJRefresh.m

### DIFF
--- a/MJRefresh/UIScrollView+MJRefresh.m
+++ b/MJRefresh/UIScrollView+MJRefresh.m
@@ -40,7 +40,7 @@ static const char MJRefreshHeaderKey = '\0';
         // 存储新的
         [self willChangeValueForKey:@"mj_header"]; // KVO
         objc_setAssociatedObject(self, &MJRefreshHeaderKey,
-                                 mj_header, OBJC_ASSOCIATION_ASSIGN);
+                                 mj_header, OBJC_ASSOCIATION_RETAIN);
         [self didChangeValueForKey:@"mj_header"]; // KVO
     }
 }
@@ -62,7 +62,7 @@ static const char MJRefreshFooterKey = '\0';
         // 存储新的
         [self willChangeValueForKey:@"mj_footer"]; // KVO
         objc_setAssociatedObject(self, &MJRefreshFooterKey,
-                                 mj_footer, OBJC_ASSOCIATION_ASSIGN);
+                                 mj_footer, OBJC_ASSOCIATION_RETAIN);
         [self didChangeValueForKey:@"mj_footer"]; // KVO
     }
 }


### PR DESCRIPTION
OBJC_ASSOCIATION_ASSIGN 会导致系统版本的机型 Crash, 修改为 OBJC_ASSOCIATION_RETAIN