### PR TITLE
add __kindof

### DIFF
--- a/MJRefresh/UIScrollView+MJRefresh.h
+++ b/MJRefresh/UIScrollView+MJRefresh.h
@@ -14,11 +14,11 @@
 
 @interface UIScrollView (MJRefresh)
 /** 下拉刷新控件 */
-@property (strong, nonatomic) MJRefreshHeader *mj_header;
-@property (strong, nonatomic) MJRefreshHeader *header MJRefreshDeprecated("使用mj_header");
+@property (strong, nonatomic) __kindof MJRefreshHeader *mj_header;
+@property (strong, nonatomic) __kindof MJRefreshHeader *header MJRefreshDeprecated("使用mj_header");
 /** 上拉刷新控件 */
-@property (strong, nonatomic) MJRefreshFooter *mj_footer;
-@property (strong, nonatomic) MJRefreshFooter *footer MJRefreshDeprecated("使用mj_footer");
+@property (strong, nonatomic) __kindof MJRefreshFooter *mj_footer;
+@property (strong, nonatomic) __kindof MJRefreshFooter *footer MJRefreshDeprecated("使用mj_footer");
 
 #pragma mark - other
 - (NSInteger)mj_totalDataCount;


### PR DESCRIPTION

当使用自定义的头部时,下面代码会有wanrning
```
SIRefreshHeader *header = self.tableView.mj_header;
```

>  Incompatible pointer types initializing 'SIRefreshHeader *' with an expression of type 'MJRefreshHeader *'

提议加上`__kindof `来去除此类告警