### PR TITLE
将UIScrollView+MJRefresh.h文件导入到了使用的类文件的.m中

### DIFF
--- a/MJRefresh/Base/MJRefreshAutoFooter.m
+++ b/MJRefresh/Base/MJRefreshAutoFooter.m
@@ -7,6 +7,7 @@
 //
 
 #import "MJRefreshAutoFooter.h"
+#import "UIScrollView+MJRefresh.h"
 
 @interface MJRefreshAutoFooter()
 @end

--- a/MJRefresh/Base/MJRefreshBackFooter.m
+++ b/MJRefresh/Base/MJRefreshBackFooter.m
@@ -7,6 +7,7 @@
 //
 
 #import "MJRefreshBackFooter.h"
+#import "UIScrollView+MJRefresh.h"
 
 @interface MJRefreshBackFooter()
 @property (assign, nonatomic) NSInteger lastRefreshCount;

--- a/MJRefresh/Base/MJRefreshComponent.h
+++ b/MJRefresh/Base/MJRefreshComponent.h
@@ -11,7 +11,6 @@
 #import "MJRefreshConst.h"
 #import "UIView+MJExtension.h"
 #import "UIScrollView+MJExtension.h"
-#import "UIScrollView+MJRefresh.h"
 #import "NSBundle+MJRefresh.h"
 
 /** 刷新控件的状态 */

--- a/MJRefresh/Base/MJRefreshComponent.m
+++ b/MJRefresh/Base/MJRefreshComponent.m
@@ -9,6 +9,7 @@
 
 #import "MJRefreshComponent.h"
 #import "MJRefreshConst.h"
+#import "UIScrollView+MJRefresh.h"
 
 @interface MJRefreshComponent()
 @property (strong, nonatomic) UIPanGestureRecognizer *pan;

--- a/MJRefresh/Base/MJRefreshFooter.m
+++ b/MJRefresh/Base/MJRefreshFooter.m
@@ -8,6 +8,7 @@
 //
 
 #import "MJRefreshFooter.h"
+#import "UIScrollView+MJRefresh.h"
 
 @interface MJRefreshFooter()
 

--- a/MJRefresh/Base/MJRefreshHeader.m
+++ b/MJRefresh/Base/MJRefreshHeader.m
@@ -8,6 +8,7 @@
 //
 
 #import "MJRefreshHeader.h"
+#import "UIScrollView+MJRefresh.h"
 
 @interface MJRefreshHeader()
 @property (assign, nonatomic) CGFloat insetTDelta;


### PR DESCRIPTION
将UIScrollView+MJRefresh.h导入到了使用的类文件的.m中,因已经导入此头文件到MJRefresh.h中,因此此改动对使用者无影响,仅为内部改动;
目的是:外部可对UIScrollView+MJRefresh.h中的属性进行了封装,如统一通过category将mj_header改为hcb_header,此时可避免自动提示出mj_header,做到三方库源码尽量少侵入业务代码的目的;而如果要使用mj_header时,无需多做,导入MJRefresh.h即可;