### PR TITLE
`_ignoredScrollViewContentInsetTop` with immediate effect

### DIFF
--- a/MJRefresh/Base/MJRefreshHeader.m
+++ b/MJRefresh/Base/MJRefreshHeader.m
@@ -146,4 +146,13 @@
 {
     return [[NSUserDefaults standardUserDefaults] objectForKey:self.lastUpdatedTimeKey];
 }
+
+#pragma mark - 私有方法
+
+- (void)setIgnoredScrollViewContentInsetTop:(CGFloat)ignoredScrollViewContentInsetTop {
+    _ignoredScrollViewContentInsetTop = ignoredScrollViewContentInsetTop;
+    
+    self.mj_y = - self.mj_h - _ignoredScrollViewContentInsetTop;
+}
+
 @end


### PR DESCRIPTION
修复中途重置 `ignoredScrollViewContentInsetTop` 不及时修改 header.y 的问题，此时 header 早已初始化完成，不会调用 `layoutSubviews` 方法，需要等下拉后才调用该方法去修改 header.y。