### PR TITLE
解决下拉时header不收回问题

### DIFF
--- a/MJRefresh/Base/MJRefreshHeader.m
+++ b/MJRefresh/Base/MJRefreshHeader.m
@@ -54,8 +54,6 @@
     
     // 在刷新的refreshing状态
     if (self.state == MJRefreshStateRefreshing) {
-        // 暂时保留
-        if (self.window == nil) return;
         
         // sectionheader停留解决
         CGFloat insetT = - self.scrollView.mj_offsetY > _scrollViewOriginalInset.top ? - self.scrollView.mj_offsetY : _scrollViewOriginalInset.top;


### PR DESCRIPTION
Hello ,  这里会导致一个线上的问题，就是在一个页面下拉不松手，然后点击到其他控制器，过几秒再回来，header会错位。
[有问题的demo 可以看这里](https://github.com/maligh/ML-Objective-C-Demo/tree/master/TestRefresh1) ，谢谢~
```
-        // 暂时保留		
-        if (self.window == nil) return;
```

