### PR TITLE
修复MJRefresh中UIScrollView (MJExtension) 根据版本对执行代码的判断逻辑

### DIFF
--- a/MJRefresh/UIScrollView+MJExtension.m
+++ b/MJRefresh/UIScrollView+MJExtension.m
@@ -15,17 +15,17 @@
 
 @implementation UIScrollView (MJExtension)
 
-static BOOL gt_ios_11_;
+static BOOL gt_respondsToAdjustedContentInset;
 + (void)load
 {
     // 缓存判断值
-    gt_ios_11_ = ([[[UIDevice currentDevice] systemVersion] compare:@"11" options:NSNumericSearch] != NSOrderedAscending);
+    gt_respondsToAdjustedContentInset = [self respondsToSelector:@selector(adjustedContentInset)];
 }
 
 - (UIEdgeInsets)mj_inset
 {
 #ifdef __IPHONE_11_0
-    if (gt_ios_11_) {
+    if (gt_respondsToAdjustedContentInset) {
         return self.adjustedContentInset;
     }
 #endif
@@ -37,7 +37,7 @@ static BOOL gt_ios_11_;
     UIEdgeInsets inset = self.contentInset;
     inset.top = mj_insetT;
 #ifdef __IPHONE_11_0
-    if (gt_ios_11_) {
+    if (gt_respondsToAdjustedContentInset) {
         inset.top -= (self.adjustedContentInset.top - self.contentInset.top);
     }
 #endif
@@ -54,7 +54,7 @@ static BOOL gt_ios_11_;
     UIEdgeInsets inset = self.contentInset;
     inset.bottom = mj_insetB;
 #ifdef __IPHONE_11_0
-    if (gt_ios_11_) {
+    if (gt_respondsToAdjustedContentInset) {
         inset.bottom -= (self.adjustedContentInset.bottom - self.contentInset.bottom);
     }
 #endif
@@ -71,7 +71,7 @@ static BOOL gt_ios_11_;
     UIEdgeInsets inset = self.contentInset;
     inset.left = mj_insetL;
 #ifdef __IPHONE_11_0
-    if (gt_ios_11_) {
+    if (gt_respondsToAdjustedContentInset) {
         inset.left -= (self.adjustedContentInset.left - self.contentInset.left);
     }
 #endif
@@ -88,7 +88,7 @@ static BOOL gt_ios_11_;
     UIEdgeInsets inset = self.contentInset;
     inset.right = mj_insetR;
 #ifdef __IPHONE_11_0
-    if (gt_ios_11_) {
+    if (gt_respondsToAdjustedContentInset) {
         inset.right -= (self.adjustedContentInset.right - self.contentInset.right);
     }
 #endif

--- a/MJRefresh/UIScrollView+MJExtension.m
+++ b/MJRefresh/UIScrollView+MJExtension.m
@@ -15,17 +15,22 @@
 
 @implementation UIScrollView (MJExtension)
 
-static BOOL gt_respondsToAdjustedContentInset;
-+ (void)load
-{
-    // 缓存判断值
-    gt_respondsToAdjustedContentInset = [self respondsToSelector:@selector(adjustedContentInset)];
+static BOOL mj_respondsToAdjustedContentInset;
+
+- (BOOL)gt_respondsToAdjustedContentInset {
+    
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        mj_respondsToAdjustedContentInset = [self respondsToSelector:@selector(adjustedContentInset)];
+    });
+    
+    return mj_respondsToAdjustedContentInset;
 }
 
 - (UIEdgeInsets)mj_inset
 {
 #ifdef __IPHONE_11_0
-    if (gt_respondsToAdjustedContentInset) {
+    if ([self gt_respondsToAdjustedContentInset]) {
         return self.adjustedContentInset;
     }
 #endif
@@ -37,7 +42,7 @@ static BOOL gt_respondsToAdjustedContentInset;
     UIEdgeInsets inset = self.contentInset;
     inset.top = mj_insetT;
 #ifdef __IPHONE_11_0
-    if (gt_respondsToAdjustedContentInset) {
+    if ([self gt_respondsToAdjustedContentInset]) {
         inset.top -= (self.adjustedContentInset.top - self.contentInset.top);
     }
 #endif
@@ -54,7 +59,7 @@ static BOOL gt_respondsToAdjustedContentInset;
     UIEdgeInsets inset = self.contentInset;
     inset.bottom = mj_insetB;
 #ifdef __IPHONE_11_0
-    if (gt_respondsToAdjustedContentInset) {
+    if ([self gt_respondsToAdjustedContentInset]) {
         inset.bottom -= (self.adjustedContentInset.bottom - self.contentInset.bottom);
     }
 #endif
@@ -71,7 +76,7 @@ static BOOL gt_respondsToAdjustedContentInset;
     UIEdgeInsets inset = self.contentInset;
     inset.left = mj_insetL;
 #ifdef __IPHONE_11_0
-    if (gt_respondsToAdjustedContentInset) {
+    if ([self gt_respondsToAdjustedContentInset]) {
         inset.left -= (self.adjustedContentInset.left - self.contentInset.left);
     }
 #endif
@@ -88,7 +93,7 @@ static BOOL gt_respondsToAdjustedContentInset;
     UIEdgeInsets inset = self.contentInset;
     inset.right = mj_insetR;
 #ifdef __IPHONE_11_0
-    if (gt_respondsToAdjustedContentInset) {
+    if ([self gt_respondsToAdjustedContentInset]) {
         inset.right -= (self.adjustedContentInset.right - self.contentInset.right);
     }
 #endif


### PR DESCRIPTION
目前MJ的这个根据iOS版本判断执行分支代码在大范围的越狱机型方法被hook或者非越狱机型被hook的情况下出现了大范围因 unrecognized selector sent to instance 导致的crash，对这部分代码进行修改，不再判断版本，只判断能否respondsToSelector: