### PR TITLE
解决滑动手势中断带来的计算失误

### DIFF
--- a/MJRefresh/Base/MJRefreshHeader.m
+++ b/MJRefresh/Base/MJRefreshHeader.m
@@ -57,10 +57,15 @@
         // 暂时保留
         if (self.window == nil) return;
         
-        // sectionheader停留解决
-        CGFloat insetT = - self.scrollView.mj_offsetY > _scrollViewOriginalInset.top ? - self.scrollView.mj_offsetY : _scrollViewOriginalInset.top;
-        insetT = insetT > self.mj_h + _scrollViewOriginalInset.top ? self.mj_h + _scrollViewOriginalInset.top : insetT;
-        self.scrollView.mj_insetT = insetT;
+        //解决滑动手势中断带来的计算失误
+        if (self.scrollView.isDecelerating) {
+            // sectionheader停留解决
+            CGFloat insetT = - self.scrollView.mj_offsetY > _scrollViewOriginalInset.top ? - self.scrollView.mj_offsetY : _scrollViewOriginalInset.top;
+            insetT = insetT > self.mj_h + _scrollViewOriginalInset.top ? self.mj_h + _scrollViewOriginalInset.top : insetT;
+            self.scrollView.mj_insetT = insetT;
+            
+            self.insetTDelta = _scrollViewOriginalInset.top - insetT;
+        }
         
         self.insetTDelta = _scrollViewOriginalInset.top - insetT;
         return;


### PR DESCRIPTION
解决滑动手势中断带来的计算失误 [issue1170](https://github.com/CoderMJLee/MJRefresh/issues/1170)