### PR TITLE
speed up the refresh animation.

### DIFF
--- a/MJRefresh/Base/MJRefreshHeader.m
+++ b/MJRefresh/Base/MJRefreshHeader.m
@@ -137,8 +137,8 @@
                     [self.scrollView setContentOffset:offset animated:NO];
                 }
             } completion:^(BOOL finished) {
-                [self executeRefreshingCallback];
             }];
+            [self executeRefreshingCallback];
         })
     }
 }


### PR DESCRIPTION
Moving refreshingCallback from the end of the animation to the beginning. 
So when the data is processed very quickly, you can end the refreshing animation more quickly, and don't wait for MJRefreshFastAnimationDuration.

![1](https://user-images.githubusercontent.com/4262251/50957982-8f4bcd80-14fa-11e9-9bbf-22586daec243.gif)
![2](https://user-images.githubusercontent.com/4262251/50957990-92df5480-14fa-11e9-9e96-ad6f792cd77e.gif)
