### PR TITLE
feat: 增加 noDataTitleHidden 以实现无数据时隐藏状态文字

### DIFF
--- a/MJRefresh/Custom/Footer/Auto/MJRefreshAutoStateFooter.h
+++ b/MJRefresh/Custom/Footer/Auto/MJRefreshAutoStateFooter.h
@@ -17,6 +17,9 @@
 /** 设置state状态下的文字 */
 - (void)setTitle:(NSString *)title forState:(MJRefreshState)state;
 
+/** 第一次加载完成后，没有数据时是否隐藏状态文字 */
+@property (assign, nonatomic, getter=isNoDataTitleHidden) BOOL noDataTitleHidden;
+
 /** 隐藏刷新状态的文字 */
 @property (assign, nonatomic, getter=isRefreshingTitleHidden) BOOL refreshingTitleHidden;
 @end

--- a/MJRefresh/Custom/Footer/Auto/MJRefreshAutoStateFooter.m
+++ b/MJRefresh/Custom/Footer/Auto/MJRefreshAutoStateFooter.m
@@ -85,6 +85,8 @@
     
     if (self.isRefreshingTitleHidden && state == MJRefreshStateRefreshing) {
         self.stateLabel.text = nil;
+    } else if (self.isNoDataTitleHidden && state == MJRefreshStateNoMoreData && self.scrollView.mj_totalDataCount == 0) {
+        self.stateLabel.text = nil;
     } else {
         self.stateLabel.text = self.stateTitles[@(state)];
     }


### PR DESCRIPTION
现有的 MJRefreshStateNoMoreData 无法区分是否为第一次加载。
增加 noDataTitleHidden 可以在第一次加载且无数据时不显示状态，让开发者另外处理。