### PR TITLE
fix: #1262 修复下拉刷新保持停顿不松手, 此时跳转新的 VC 导致的 ScrollView Insets 异常的问题

### DIFF
--- a/MJRefresh/Base/MJRefreshHeader.m
+++ b/MJRefresh/Base/MJRefreshHeader.m
@@ -93,7 +93,17 @@
         }
     } else if (self.state == MJRefreshStatePulling) {// 即将刷新 && 手松开
         // 开始刷新
-        [self beginRefreshing];
+        
+        if (self.window == nil) {
+            
+            [self beginRefreshing];
+            
+        } else {
+            
+            [self endRefreshing];
+            
+        }
+        
     } else if (pullingPercent < 1) {
         self.pullingPercent = pullingPercent;
     }

--- a/MJRefresh/Base/MJRefreshHeader.m
+++ b/MJRefresh/Base/MJRefreshHeader.m
@@ -94,6 +94,14 @@
     } else if (self.state == MJRefreshStatePulling) {// 即将刷新 && 手松开
         // 开始刷新
         
+        /**
+         
+         已修复
+         Bug编号: #1262
+         Bug链接: https://github.com/CoderMJLee/MJRefresh/issues/1262
+        
+         */
+        
         if (self.window == nil) {
             
             [self beginRefreshing];


### PR DESCRIPTION
1 修复Bug #1262