### PR TITLE
Delete hook UITableView&UICollectionView `reloadData` exchange method code

### DIFF
--- a/MJRefresh/UIScrollView+MJRefresh.h
+++ b/MJRefresh/UIScrollView+MJRefresh.h
@@ -22,5 +22,5 @@
 
 #pragma mark - other
 - (NSInteger)mj_totalDataCount;
-//@property (copy, nonatomic) void (^mj_reloadDataBlock)(NSInteger totalDataCount);
+
 @end

--- a/MJRefresh/UIScrollView+MJRefresh.m
+++ b/MJRefresh/UIScrollView+MJRefresh.m
@@ -12,20 +12,6 @@
 #import "MJRefreshFooter.h"
 #import <objc/runtime.h>
 
-@implementation NSObject (MJRefresh)
-
-+ (void)exchangeInstanceMethod1:(SEL)method1 method2:(SEL)method2
-{
-    method_exchangeImplementations(class_getInstanceMethod(self, method1), class_getInstanceMethod(self, method2));
-}
-
-+ (void)exchangeClassMethod1:(SEL)method1 method2:(SEL)method2
-{
-    method_exchangeImplementations(class_getClassMethod(self, method1), class_getClassMethod(self, method2));
-}
-
-@end
-
 @implementation UIScrollView (MJRefresh)
 
 #pragma mark - header
@@ -88,6 +74,7 @@ static const char MJRefreshFooterKey = '\0';
 {
     return self.mj_header;
 }
+
 #pragma mark - other
 - (NSInteger)mj_totalDataCount
 {
@@ -107,52 +94,5 @@ static const char MJRefreshFooterKey = '\0';
     }
     return totalCount;
 }
+
 @end
-//static const char MJRefreshReloadDataBlockKey = '\0';
-//- (void)setMj_reloadDataBlock:(void (^)(NSInteger))mj_reloadDataBlock
-//{
-//    [self willChangeValueForKey:@"mj_reloadDataBlock"]; // KVO
-//    objc_setAssociatedObject(self, &MJRefreshReloadDataBlockKey, mj_reloadDataBlock, OBJC_ASSOCIATION_COPY_NONATOMIC);
-//    [self didChangeValueForKey:@"mj_reloadDataBlock"]; // KVO
-//}
-//
-//- (void (^)(NSInteger))mj_reloadDataBlock
-//{
-//    return objc_getAssociatedObject(self, &MJRefreshReloadDataBlockKey);
-//}
-
-//- (void)executeReloadDataBlock
-//{
-//    !self.mj_reloadDataBlock ? : self.mj_reloadDataBlock(self.mj_totalDataCount);
-//}
-//@end
-//
-//@implementation UITableView (MJRefresh)
-//
-//+ (void)load
-//{
-//    [self exchangeInstanceMethod1:@selector(reloadData) method2:@selector(mj_reloadData)];
-//}
-//
-//- (void)mj_reloadData
-//{
-//    [self mj_reloadData];
-//
-//    [self executeReloadDataBlock];
-//}
-//@end
-
-//@implementation UICollectionView (MJRefresh)
-//
-//+ (void)load
-//{
-//    [self exchangeInstanceMethod1:@selector(reloadData) method2:@selector(mj_reloadData)];
-//}
-//
-//- (void)mj_reloadData
-//{
-//    [self mj_reloadData];
-//
-//    [self executeReloadDataBlock];
-//}
-//@end

--- a/MJRefreshExample.xcodeproj/project.pbxproj
+++ b/MJRefreshExample.xcodeproj/project.pbxproj
@@ -600,7 +600,7 @@
 			};
 			buildConfigurationList = 2DA7F9201AA6B4C4005627AB /* Build configuration list for PBXProject "MJRefreshExample" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,


### PR DESCRIPTION
Hook UITableView&UICollectionView `reloadData`方法容易产生刷新无效的bug，在上一个版本，已经去掉hook相关的代码，方法交换的方法也不需要用上，所以应该删除掉。

Note:
`developmentRegion = English;` ->  `developmentRegion = en;`
 仅仅是新版Xcode自动修复的结果，消除编译⚠️
			