### PR TITLE
修改bug，`self.mj_x = -_scrollView.mj_insetL` 不生效

### DIFF
--- a/MJRefresh/Base/MJRefreshComponent.m
+++ b/MJRefresh/Base/MJRefreshComponent.m
@@ -55,13 +55,14 @@
     [self removeObservers];
     
     if (newSuperview) { // 新的父控件
-        // 设置宽度
-        self.mj_w = newSuperview.mj_w;
-        // 设置位置
-        self.mj_x = -_scrollView.mj_insetL;
-        
         // 记录UIScrollView
         _scrollView = (UIScrollView *)newSuperview;
+        
+        // 设置宽度
+        self.mj_w = _scrollView.mj_w;
+        // 设置位置
+        self.mj_x = -_scrollView.mj_insetL;
+    
         // 设置永远支持垂直弹簧效果
         _scrollView.alwaysBounceVertical = YES;
         // 记录UIScrollView最开始的contentInset


### PR DESCRIPTION
修改bug，在scrollview的contentInset的left有值时刷新内容不居中，您已经加了相关逻辑，但未生效。
```
@implementation MJRefreshComponent
- (void)willMoveToSuperview:(UIView *)newSuperview
{
    [super willMoveToSuperview:newSuperview];
    
    // 如果不是UIScrollView，不做任何事情
    if (newSuperview && ![newSuperview isKindOfClass:[UIScrollView class]]) return;
    
    // 旧的父控件移除监听
    [self removeObservers];
    
    if (newSuperview) { // 新的父控件
        // 设置宽度
        self.mj_w = newSuperview.mj_w;
        // 设置位置
        self.mj_x = -_scrollView.mj_insetL;
        
        // 记录UIScrollView
        _scrollView = (UIScrollView *)newSuperview;
        // 设置永远支持垂直弹簧效果
        _scrollView.alwaysBounceVertical = YES;
        // 记录UIScrollView最开始的contentInset
        _scrollViewOriginalInset = _scrollView.mj_inset;
        
        // 添加监听
        [self addObservers];
    }
}
@end
```
在 ` self.mj_x = -_scrollView.mj_insetL;` 时，`_scrollView` 还没有值，所以 `self.mj_x` 永远是0。不会根据 `scrollView` 的 `mj_insetL` 反向移动。  
如果 `scrollView` 设置了 `contentInset` 则 `header` 、`footer` 的内容都会偏移 `self.mj_x`，不居中。

调整如下，移动代码顺序
```
  // 设置宽度
        self.mj_w = newSuperview.mj_w;
        
        // 记录UIScrollView
        _scrollView = (UIScrollView *)newSuperview;
        
        // 设置位置
        self.mj_x = -_scrollView.mj_insetL;
    
        // 设置永远支持垂直弹簧效果
        _scrollView.alwaysBounceVertical = YES;
        // 记录UIScrollView最开始的contentInset
        _scrollViewOriginalInset = _scrollView.mj_inset;
        
        // 添加监听
        [self addObservers];
```
