### PR TITLE
修复“设置 onlyRefreshPerDrag 为 YES ， 点击 footer 后未开始刷新(#1307)”的 Bug

### DIFF
--- a/MJRefresh/Base/MJRefreshAutoFooter.h
+++ b/MJRefresh/Base/MJRefreshAutoFooter.h
@@ -20,4 +20,8 @@
 
 /** 是否每一次拖拽只发一次请求 */
 @property (assign, nonatomic, getter=isOnlyRefreshPerDrag) BOOL onlyRefreshPerDrag;
+
+/** 是否通过点击 footer 触发的刷新 */
+@property (assign, nonatomic, getter=isTriggeredByTapGesture) BOOL triggeredByTapGesture;
+
 @end

--- a/MJRefresh/Base/MJRefreshAutoFooter.m
+++ b/MJRefresh/Base/MJRefreshAutoFooter.m
@@ -112,11 +112,14 @@
 
 - (void)beginRefreshing
 {
-    if (!self.isOneNewPan && self.isOnlyRefreshPerDrag) return;
+    if (!self.isOneNewPan && self.isOnlyRefreshPerDrag && !self.isTriggeredByTapGesture) {
+        return;
+    }
     
     [super beginRefreshing];
     
     self.oneNewPan = NO;
+    self.triggeredByTapGesture = NO;
 }
 
 - (void)setState:(MJRefreshState)state

--- a/MJRefresh/Custom/Footer/Auto/MJRefreshAutoStateFooter.m
+++ b/MJRefresh/Custom/Footer/Auto/MJRefreshAutoStateFooter.m
@@ -47,6 +47,7 @@
 - (void)stateLabelClick
 {
     if (self.state == MJRefreshStateIdle) {
+        self.triggeredByTapGesture = YES;
         [self beginRefreshing];
     }
 }


### PR DESCRIPTION
相关 issue https://github.com/CoderMJLee/MJRefresh/issues/1307 

简介：MJRefreshAutoStateFooter 添加 triggeredByTapGesture 属性，用于标识是否是通过点击 footer 触发的刷新