### PR TITLE
Add support for swift package manage

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,9 +5,6 @@ import PackageDescription
 
 let package = Package(
     name: "MJRefresh",
-    platforms: [
-        .iOS(.v8)
-    ],
     products: [
        .library(name: "MJRefresh", targets: ["MJRefresh"])
    ],

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version:4.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "MJRefresh",
+    platforms: [
+        .iOS(.v8)
+    ],
+    products: [
+       .library(name: "MJRefresh", targets: ["MJRefresh"])
+   ],
+    targets: [
+       .target(
+           name: "MJRefresh",
+           path: "MJRefresh"
+       )
+   ]
+)


### PR DESCRIPTION
Xcode 11 introduce the support for Swift Package Manager (SwiftPM).  It supports for not only Swift files, but also the C/C++ files.

So, since MJRefresh is written in Objective-C, it should be supported. 

The `Package.swift` is like the `podspec`, a rule to define the compile and target. See the full documentation for [Package.swift syntax](https://github.com/apple/swift-package-manager/blob/master/Documentation/PackageDescription.md)