### PR TITLE
footer.triggerAutomaticallyRefreshPercent小于1时，偶尔会同时触发下拉刷新和加载更多

### DIFF
--- a/MJRefresh/Base/MJRefreshAutoFooter.m
+++ b/MJRefresh/Base/MJRefreshAutoFooter.m
@@ -81,6 +81,7 @@
             CGPoint old = [change[@"old"] CGPointValue];
             CGPoint new = [change[@"new"] CGPointValue];
             if (new.y <= old.y) return;
+            if (new.y <= 0) return;
             
             // 当底部刷新控件完全出现时，才刷新
             [self beginRefreshing];


### PR DESCRIPTION
当数据较少且footer.triggerAutomaticallyRefreshPercent小于1时，进行下拉刷新操作会同时触发“下拉刷新”和“加载更多”两个动作