### PR TITLE
Header刷新不回弹的问题

### DIFF
--- a/MJRefresh/Base/MJRefreshHeader.m
+++ b/MJRefresh/Base/MJRefreshHeader.m
@@ -136,21 +136,19 @@
             }
         }];
     } else if (state == MJRefreshStateRefreshing) {
-        MJRefreshDispatchAsyncOnMainQueue({
-            [UIView animateWithDuration:MJRefreshFastAnimationDuration animations:^{
-                if (self.scrollView.panGestureRecognizer.state != UIGestureRecognizerStateCancelled) {
-                    CGFloat top = self.scrollViewOriginalInset.top + self.mj_h;
-                    // 增加滚动区域top
-                    self.scrollView.mj_insetT = top;
-                    // 设置滚动位置
-                    CGPoint offset = self.scrollView.contentOffset;
-                    offset.y = -top;
-                    [self.scrollView setContentOffset:offset animated:NO];
-                }
-            } completion:^(BOOL finished) {
-                [self executeRefreshingCallback];
-            }];
-        })
+        CGFloat top = self.scrollViewOriginalInset.top + self.mj_h;
+        // 增加滚动区域top
+        self.scrollView.mj_insetT = top;
+        // 设置滚动位置
+        CGPoint offset = self.scrollView.contentOffset;
+        offset.y = -top;
+        [UIView animateWithDuration:MJRefreshFastAnimationDuration animations:^{
+            if (self.scrollView.panGestureRecognizer.state != UIGestureRecognizerStateCancelled) {
+                [self.scrollView setContentOffset:offset animated:NO];
+            }
+        } completion:^(BOOL finished) {
+            [self executeRefreshingCallback];
+        }];
     }
 }
 

--- a/MJRefresh/Base/MJRefreshHeader.m
+++ b/MJRefresh/Base/MJRefreshHeader.m
@@ -137,13 +137,13 @@
         }];
     } else if (state == MJRefreshStateRefreshing) {
         CGFloat top = self.scrollViewOriginalInset.top + self.mj_h;
-        // 增加滚动区域top
-        self.scrollView.mj_insetT = top;
-        // 设置滚动位置
         CGPoint offset = self.scrollView.contentOffset;
         offset.y = -top;
         [UIView animateWithDuration:MJRefreshFastAnimationDuration animations:^{
             if (self.scrollView.panGestureRecognizer.state != UIGestureRecognizerStateCancelled) {
+                // 增加滚动区域top
+                self.scrollView.mj_insetT = top;
+                // 设置滚动位置
                 [self.scrollView setContentOffset:offset animated:NO];
             }
         } completion:^(BOOL finished) {


### PR DESCRIPTION
在状态变化时，我不太明白当初为什么单独在UI切换至MJRefreshStateRefreshing状态时使用DispatchAsync，而在切换至MJRefreshStateIdle状态时不使用DispatchAsync。
我认为setState的调用者应该确保在主线程调用的，而不是在set方法内再用异步分发到主线程。

这里做DispatchAsync只会造成一个严重点问题：
如果beginRefreshing和endRefreshing在很近的时间段调用（这很常见，比如网络请求完成调用endRefreshing后，刚好用户又点击了TabBar按钮触发beginRefreshing），由于异步分发，可能会先执行恢复滚动区域再执行增加滚动区域， 造成头部累积增加contentInset.top，体验相当糟糕。

所以我去掉了MJRefreshDispatchAsyncOnMainQueue()部分，经过有限的测试没有发现其他问题。