### PR TITLE
修复 BackNormalFooter 从刷新状态被设置为闲置状态动画结束后的过滤判断条件

### DIFF
--- a/MJRefresh/Custom/Footer/Back/MJRefreshBackNormalFooter.m
+++ b/MJRefresh/Custom/Footer/Back/MJRefreshBackNormalFooter.m
@@ -91,7 +91,7 @@
                 self.loadingView.alpha = 0.0;
             } completion:^(BOOL finished) {
                 // 防止动画结束后，状态已经不是MJRefreshStateIdle
-                if (state != MJRefreshStateIdle) return;
+                if (self.state != MJRefreshStateIdle) return;
                 
                 self.loadingView.alpha = 1.0;
                 [self.loadingView stopAnimating];


### PR DESCRIPTION
~在block里使用变量会被block引用，所以这个判断永远无效。应该用self.statue判断，因为这里已经改变了。~

状态改变依赖于现值而不是设置的旧值导致原本的过滤条件失效