### PR TITLE
对swift 友好

### DIFF
--- a/MJRefresh/UIScrollView+MJRefresh.h
+++ b/MJRefresh/UIScrollView+MJRefresh.h
@@ -14,11 +14,11 @@
 
 @interface UIScrollView (MJRefresh)
 /** 下拉刷新控件 */
-@property (strong, nonatomic) MJRefreshHeader *mj_header;
-@property (strong, nonatomic) MJRefreshHeader *header MJRefreshDeprecated("使用mj_header");
+@property (strong, nonatomic, nullable) MJRefreshHeader *mj_header;
+@property (strong, nonatomic, nullable) MJRefreshHeader *header MJRefreshDeprecated("使用mj_header");
 /** 上拉刷新控件 */
-@property (strong, nonatomic) MJRefreshFooter *mj_footer;
-@property (strong, nonatomic) MJRefreshFooter *footer MJRefreshDeprecated("使用mj_footer");
+@property (strong, nonatomic, nullable) MJRefreshFooter *mj_footer;
+@property (strong, nonatomic, nullable) MJRefreshFooter *footer MJRefreshDeprecated("使用mj_footer");
 
 #pragma mark - other
 - (NSInteger)mj_totalDataCount;


### PR DESCRIPTION
目前在swift 使用MJRefresh 时，发现这几个属性是强类型的(一定有值)，造成如果没有赋值的情况下，有些地方不小心使用到了会造成程序崩溃。