### PR TITLE
修复MJRefreshNormalHeader计算arrowView的centerX姿势不对的问题

### DIFF
--- a/MJRefresh/Custom/Header/MJRefreshNormalHeader.m
+++ b/MJRefresh/Custom/Header/MJRefreshNormalHeader.m
@@ -75,7 +75,7 @@
             timeWidth = self.lastUpdatedTimeLabel.mj_textWidth;
         }
         CGFloat textWidth = MAX(stateWidth, timeWidth);
-        arrowCenterX -= textWidth / 2 + self.labelLeftInset;
+        arrowCenterX -= textWidth / 2 + self.labelLeftInset + self.arrowView.image.size.width * 0.5;
     }
     CGFloat arrowCenterY = self.mj_h * 0.5;
     CGPoint arrowCenter = CGPointMake(arrowCenterX, arrowCenterY);

--- a/MJRefresh/MJRefreshConst.m
+++ b/MJRefresh/MJRefreshConst.m
@@ -2,7 +2,7 @@
 //  代码地址: http://code4app.com/ios/%E5%BF%AB%E9%80%9F%E9%9B%86%E6%88%90%E4%B8%8B%E6%8B%89%E4%B8%8A%E6%8B%89%E5%88%B7%E6%96%B0/52326ce26803fabc46000000
 #import <UIKit/UIKit.h>
 
-const CGFloat MJRefreshLabelLeftInset = 25;
+const CGFloat MJRefreshLabelLeftInset = 15;
 const CGFloat MJRefreshHeaderHeight = 54.0;
 const CGFloat MJRefreshFooterHeight = 44.0;
 const CGFloat MJRefreshTrailWidth = 60.0;


### PR DESCRIPTION
计算centerX的时候需要减去图片宽度的一半