### PR TITLE
Fix Bug:带灵动导的机型在某些场景中下拉刷新死循环

### DIFF
--- a/MJRefresh/Base/MJRefreshHeader.m
+++ b/MJRefresh/Base/MJRefreshHeader.m
@@ -65,7 +65,7 @@ NSString * const MJRefreshHeaderRefreshingBoundsKey = @"MJRefreshHeaderRefreshin
     insetT = insetT > self.mj_h + _scrollViewOriginalInset.top ? self.mj_h + _scrollViewOriginalInset.top : insetT;
     self.insetTDelta = _scrollViewOriginalInset.top - insetT;
     // 避免 CollectionView 在使用根据 Autolayout 和 内容自动伸缩 Cell, 刷新时导致的 Layout 异常渲染问题
-    if (self.scrollView.mj_insetT != insetT) {
+    if (fabs(self.scrollView.mj_insetT - insetT) > 0.0000001) {
         self.scrollView.mj_insetT = insetT;
     }
 }


### PR DESCRIPTION
关联 #1575 
Fix Bug:带灵动导的机型的adjustedContentInset.top(包含safeAreaInsets.top)返回一个浮点数精度极高的异常值 影响判断 下拉刷新造成死循环

复现case:
1、ViewController 在viewWillAppear里 edgesForExtendedLayout.insert(.top) 
2、scrollView的edges equal to superView布局
3、scrollView设置了contentInsets.top 比如32
4、执行下拉刷新
@CoderMJLee  @wolfcon 
![截屏2022-09-27 19 34 46](https://user-images.githubusercontent.com/15622429/192514922-12204eef-2d4c-4512-b92c-d67ad69a3d9b.png)
