### PR TITLE
fixed crash loop infinitive when compare float by using FLT_EPSILON

### DIFF
--- a/MJRefresh/Base/MJRefreshHeader.m
+++ b/MJRefresh/Base/MJRefreshHeader.m
@@ -65,7 +65,7 @@ NSString * const MJRefreshHeaderRefreshingBoundsKey = @"MJRefreshHeaderRefreshin
     insetT = insetT > self.mj_h + _scrollViewOriginalInset.top ? self.mj_h + _scrollViewOriginalInset.top : insetT;
     self.insetTDelta = _scrollViewOriginalInset.top - insetT;
     // 避免 CollectionView 在使用根据 Autolayout 和 内容自动伸缩 Cell, 刷新时导致的 Layout 异常渲染问题
-    if (self.scrollView.mj_insetT != insetT) {
+    if (fabs(self.scrollView.mj_insetT - insetT) > FLT_EPSILON) {
         self.scrollView.mj_insetT = insetT;
     }
 }


### PR DESCRIPTION
This PR is to improvement fix this crash 

https://github.com/CoderMJLee/MJRefresh/issues/1461

Look compare float equal on not correct in some case 

https://stackoverflow.com/questions/4732645/iphone-objective-c-comparing-doubles-not-working

This debug log has demonstrated this issue
  ```
 if (fabs(self.scrollView.mj_insetT - insetT) > FLT_EPSILON) {
        self.scrollView.mj_insetT = insetT;
    }else{
      if (self.scrollView.mj_insetT != insetT ) {
        NSLog(@"_--------- same value dif epsilon %f  %f ", self.scrollView.mj_insetT, insetT);
      }
    }

```
2023-04-02 10:09:15.886546+0700 App[58013:10076967] _--------- same value dif epsilon 172.333333  172.333333