### PR TITLE
修复MJRefreshAutoFooter初始化时没有添加底部忽略间距的问题

### DIFF
--- a/MJRefresh/Base/MJRefreshAutoFooter.m
+++ b/MJRefresh/Base/MJRefreshAutoFooter.m
@@ -31,7 +31,7 @@
         }
         
         // 设置位置
-        self.mj_y = _scrollView.mj_contentH;
+        self.mj_y = _scrollView.mj_contentH + self.ignoredScrollViewContentInsetBottom;
     } else { // 被移除了
         if (self.hidden == NO) {
             self.scrollView.mj_insetB -= self.mj_h;
@@ -205,7 +205,7 @@
         self.scrollView.mj_insetB += self.mj_h;
         
         // 设置位置
-        self.mj_y = _scrollView.mj_contentH;
+        self.mj_y = _scrollView.mj_contentH + self.ignoredScrollViewContentInsetBottom;
     }
 }
 


### PR DESCRIPTION
如果footer设置了ignoredScrollViewContentInsetBottom，当列表【刷新后】才添加footer，并且列表【内容不足一页】时，ignoredScrollViewContentInsetBottom并不会生效：
![581703060091_ pic](https://github.com/CoderMJLee/MJRefresh/assets/13127665/1f5a3588-af8e-4f4b-9ee7-ae6c50c15d18)

需要滑动列表才会修正，原因是因为刚添加到列表上时并没有添加ignoredScrollViewContentInsetBottom，修正后就好了：
![591703060152_ pic](https://github.com/CoderMJLee/MJRefresh/assets/13127665/b28f4763-7f1d-450c-b038-dbdbb87c1718)
