### PR TITLE
MJRefreshDispatchAsyncOnMainQueue 添加主线程判断

### DIFF
--- a/MJRefresh/MJRefreshConst.h
+++ b/MJRefresh/MJRefreshConst.h
@@ -75,11 +75,15 @@ if (state == oldState) return; \
 
 // 异步主线程执行，不强持有Self
 #define MJRefreshDispatchAsyncOnMainQueue(x) \
+if (NSThread.isMainThread) { \
+{x} \
+} else { \
 __weak typeof(self) weakSelf = self; \
 dispatch_async(dispatch_get_main_queue(), ^{ \
 typeof(weakSelf) self = weakSelf; \
 {x} \
-});
+}); \
+}
 
 /// 替换方法实现
 /// @param _fromClass 源类


### PR DESCRIPTION
主要解决这个问题：对`footer`进行`resetNoMoreData`之后，如果直接调用`footer.beginRefreshing`时，由于`resetNoMoreData`中对`state`的更改是在下次主线程中执行，这样就导致`footer`不显示`loading`动画。
效果参照下图：
![修改之前的效果](https://github.com/CoderMJLee/MJRefresh/assets/11711768/31618033-3fad-45b7-a4b9-9b294598a5ac)

![修改之后的效果](https://github.com/CoderMJLee/MJRefresh/assets/11711768/0757a2f8-0103-465d-b548-a67e537633c4)

